### PR TITLE
Update nunjucks to fix problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "workaround": "node index.js 10000 workaround-a.html"
   },
   "dependencies": {
-    "nunjucks": "2.3.0"
+    "nunjucks": "2.4.2"
   }
 }


### PR DESCRIPTION
There is no such problem with fresh version of nunjucks(2.4.2)

```
test git:(master) npm test

> nunjucks-include-range-error@ test /Users/g.khudyakov/projects/test
> npm run problem


> nunjucks-include-range-error@ problem /Users/g.khudyakov/projects/test
> node index.js 10000 problem-a.html

done: 10000 files

```

even with with increased count:

```
test git:(master) node index.js 1000000 problem-a.html
done: 1000000 files
test git:(master) 

```
